### PR TITLE
Deploy changes to lambda

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,3 +37,12 @@ jobs:
         run: npm run lint  
       - name: Test
         run: npm test
+  trigger_deploy:
+    if: github.ref == 'refs/heads/master'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: trigger deploy
+        run: gh workflow run release --ref master -F environment=staging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+run-name: Release to ${{ inputs.environment || 'staging' }} by @${{ github.actor }}
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to run deployment in'
+        type: environment
+        required: true
+        default: staging
+
+jobs:
+  deploy:
+    uses: Stackla/stackla-github-actions/.github/workflows/serverless.yml@master
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}

--- a/esbuild.js
+++ b/esbuild.js
@@ -10,7 +10,7 @@ const widgets = ["carousel", "nightfall", "waterfall"]
 const config = {
   entryPoints: [...widgets.map(widget => `widgets/${widget}/widget.ts`)],
   bundle: true,
-  outdir: "dist",
+  outdir: "dist/widgets",
   loader: {
     ".hbs": "text",
     ".css": "text"
@@ -46,18 +46,18 @@ widgets.forEach(widget => {
     style: env === "development" ? "expanded" : "compressed"
   })
 
-  const widgetCSSPath = `dist/${widget}/widget.css`
-  const tileHbsPath = `widgets/${widget}/tile.hbs`
-  const widgetHbsPath = `widgets/${widget}/layout.hbs`
+  const widgetCSSPath = `dist/widgets/${widget}/widget.css`
+  const tileHbsSourcePath = `widgets/${widget}/tile.hbs`
+  const widgetHbsSourcePath = `widgets/${widget}/layout.hbs`
 
   ensureDirectoryExistence(widgetCSSPath)
   fs.writeFileSync(widgetCSSPath, result.css.toString())
 
-  ensureDirectoryExistence(tileHbsPath)
-  const tileHbs = fs.readFileSync(tileHbsPath, "utf8")
-  fs.writeFileSync(`dist/${widget}/tile.hbs`, tileHbs)
+  ensureDirectoryExistence(tileHbsSourcePath)
+  const tileHbs = fs.readFileSync(tileHbsSourcePath, "utf8")
+  fs.writeFileSync(`dist/widgets/${widget}/tile.hbs`, tileHbs)
 
-  ensureDirectoryExistence(widgetHbsPath)
-  const widgetHbs = fs.readFileSync(widgetHbsPath, "utf8")
-  fs.writeFileSync(`dist/${widget}/layout.hbs`, widgetHbs)
+  ensureDirectoryExistence(widgetHbsSourcePath)
+  const widgetHbs = fs.readFileSync(widgetHbsSourcePath, "utf8")
+  fs.writeFileSync(`dist/widgets/${widget}/layout.hbs`, widgetHbs)
 })

--- a/src/libs/express.ts
+++ b/src/libs/express.ts
@@ -10,7 +10,7 @@ expressApp.use((_req, res, next) => {
   res.set("Cache-Control", "public, max-age=300")
   next()
 })
-expressApp.use(express.static("dist", { redirect: false }))
+expressApp.use(express.static("dist/widgets", { redirect: false }))
 expressApp.set("view engine", "hbs")
 expressApp.use(cors())
 
@@ -22,7 +22,7 @@ expressApp.get("/preview", (req, res) => {
     return res.status(400).send("widgetType is required")
   }
 
-  const rootDir = path.resolve(__dirname, `../../../../../dist/${widgetType}`)
+  const rootDir = path.resolve(__dirname, `../../../../../dist/widgets/${widgetType}`)
 
   const layout = `${rootDir}/layout.hbs`
   const tile = `${rootDir}/tile.hbs`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
Our lambda should be deployed in staging & production, so that we can retrieve the following:
1) Widget css file
2) Widget js file
3) Widget hbs file 
4) Tile hbs file

These will automatically be pulled by our template gallery when new changes are made.

 