### PR TITLE
Add missing swiper styles back

### DIFF
--- a/widgets/carousel/widget.templates.ts
+++ b/widgets/carousel/widget.templates.ts
@@ -1,6 +1,7 @@
 import { loadExpandedTileTemplates } from "./components/expanded-tile"
 import { loadProductsTemplate } from "./components/products"
 import { loadShopspotTemplates } from "./components/shopspot-icon"
+import { loadSwiperStyles } from "@libs/extensions/swiper"
 import icons from "../../uikit/icon.scss"
 import { Sdk } from "@stackla/ugc-widgets"
 
@@ -10,5 +11,6 @@ export function loadCustomisation() {
   loadProductsTemplate()
   loadExpandedTileTemplates()
   loadShopspotTemplates()
+  loadSwiperStyles()
   sdk.addSharedCssCustomStyles(icons)
 }

--- a/widgets/libs/extensions/swiper/index.ts
+++ b/widgets/libs/extensions/swiper/index.ts
@@ -1,0 +1,17 @@
+import { Sdk } from "@stackla/ugc-widgets"
+import swiperFont from "./swiper-font.scss"
+import swiperCommon from "./swiper-common.scss"
+import swiperBundleCss from "@swiper/swiper-bundle.css"
+
+declare const sdk: Sdk
+
+export function loadSwiperStyles() {
+  // some of the css styles are inherited across the shadow DOM components
+  // https://www.w3.org/TR/CSS22/propidx.html#q0
+  // Injects @font-face into placement head
+  sdk.addWidgetCustomStyles(swiperFont)
+
+  // Swiper specific styles to be available for both carousel and expanded tile
+  sdk.addSharedCssCustomStyles(swiperBundleCss)
+  sdk.addSharedCssCustomStyles(swiperCommon)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
The refactoring in PR https://github.com/Stackla/stackla-widget-templates/pull/82 removed the imports for swiper style enhancements. This PR adds them back preserving encapsulation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 