### PR TITLE
allow CloudFront to invoke Lambda functions

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -8,5 +8,8 @@
     "role": {
       "statements": []
     }
+  },
+  "cloudfront": {
+    "sourceArn": "arn:aws:cloudfront::953585160895:distribution/E28OW241RQ7NYT"
   }
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -8,5 +8,8 @@
     "role": {
       "statements": []
     }
+  },
+  "cloudfront": {
+    "sourceArn": "arn:aws:cloudfront::953585160895:distribution/E18IL0OCH6JA5Z"
   }
 }

--- a/serverless.ts
+++ b/serverless.ts
@@ -68,7 +68,23 @@ const config = {
         ]
       })
     }
-  }
+  },
+  resources: {
+    Resources: {
+      CloudfrontPermissionGrant: {
+        Type: 'AWS::Lambda::Permission',
+        Properties: {
+          Action: 'lambda:InvokeFunctionUrl',
+          FunctionName: {
+            Ref: 'MainLambdaFunction',
+          },
+          Principal: 'cloudfront.amazonaws.com',
+          SourceArn:
+            '${file(./config/${self:provider.stage}.json):cloudfront.sourceArn}' as any,
+        },
+      },
+    },
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
Allow CloudFront access to invoke Lambda function
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html

Ticket: https://nostosolutions.atlassian.net/browse/UGCSRE-483

 