### PR TITLE
Update widget-utils version to 0.1.41 and adjust Lambda configuration for staging environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25816,7 +25816,7 @@
     },
     "packages/widget-utils": {
       "name": "@stackla/widget-utils",
-      "version": "0.1.39",
+      "version": "0.1.41",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",

--- a/serverless.ts
+++ b/serverless.ts
@@ -102,7 +102,9 @@ const config = {
           }
         ]
       }),
-      memorySize: 128
+      memorySize: 128,
+      // Lambda @ Edge in production does not support provisioned concurrency
+      provisionedConcurrency: process.env.APP_ENV === "staging" ? 1 : 0
     }
   }
 };

--- a/serverless.ts
+++ b/serverless.ts
@@ -102,7 +102,7 @@ const config = {
           }
         ]
       }),
-      memorySize: 128,
+      memorySize: process.env.APP_ENV === 'production' ? 128 : 1024,
       // Lambda @ Edge in production does not support provisioned concurrency
       provisionedConcurrency: process.env.APP_ENV === "staging" ? 1 : 0
     }

--- a/serverless.ts
+++ b/serverless.ts
@@ -109,4 +109,11 @@ const config = {
   }
 };
 
+if (process.env.APP_ENV !== 'production') {
+  // @ts-expect-error
+  config.provider.environment = {
+    APP_ENV: env
+  }
+}
+
 module.exports = config;

--- a/src/libs/express.ts
+++ b/src/libs/express.ts
@@ -54,10 +54,15 @@ expressApp.use(express.static("dist", { redirect: false }))
 
 if (process.env.APP_ENV == "staging" || process.env.APP_ENV == "production") {
   expressApp.use((_req, res, next) => {
-    res.set("Cache-Control", "public, max-age=3600")
+    res.set("Cache-Control", ["public, max-age=3600"])
     next()
   })
 }
+
+expressApp.use(function (req, res, next) {
+  res.removeHeader("x-powered-by");
+  next();
+});
 
 expressApp.engine("hbs", Handlebars.__express)
 expressApp.set("view engine", "hbs")

--- a/src/libs/express.ts
+++ b/src/libs/express.ts
@@ -50,7 +50,11 @@ type PreviewContent = {
 }
 
 const expressApp = express()
-expressApp.use(express.static("dist", { redirect: false }))
+
+expressApp.use(function (req, res, next) {
+  res.removeHeader("x-powered-by");
+  next();
+});
 
 if (process.env.APP_ENV == "staging" || process.env.APP_ENV == "production") {
   expressApp.use((_req, res, next) => {
@@ -59,10 +63,7 @@ if (process.env.APP_ENV == "staging" || process.env.APP_ENV == "production") {
   })
 }
 
-expressApp.use(function (req, res, next) {
-  res.removeHeader("x-powered-by");
-  next();
-});
+expressApp.use(express.static("dist", { redirect: false }))
 
 expressApp.engine("hbs", Handlebars.__express)
 expressApp.set("view engine", "hbs")

--- a/src/libs/express.ts
+++ b/src/libs/express.ts
@@ -50,7 +50,7 @@ type PreviewContent = {
 }
 
 const expressApp = express()
-
+expressApp.disable('x-powered-by');
 expressApp.use(function (req, res, next) {
   res.removeHeader("x-powered-by");
   next();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
Lambda edge requires headers to be arrays.
provisionedConcurrency is not supported in prod but leaving it in staging for the moment to keep decent availability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 