### PR TITLE
Remove blur and brightness to show image when video is loading

### DIFF
--- a/cypress/support/expanded-tile.js
+++ b/cypress/support/expanded-tile.js
@@ -13,7 +13,7 @@ Cypress.Commands.add("shouldExpandedTile", widgetType => {
   cy.getExpandedTile().should("exist")
 
   // Set visibility to hidden for all images
-  cy.getExpandedTile().find(".image-filter").should("exist").invoke("css", "visibility", "hidden")
+  cy.getExpandedTile().find(".image-filler").should("exist").invoke("css", "visibility", "hidden")
 
   cy.wait(1000)
 

--- a/cypress/support/expanded-tile.js
+++ b/cypress/support/expanded-tile.js
@@ -13,7 +13,7 @@ Cypress.Commands.add("shouldExpandedTile", widgetType => {
   cy.getExpandedTile().should("exist")
 
   // Set visibility to hidden for all images
-  cy.getExpandedTile().find(".image-element").should("exist").invoke("css", "visibility", "hidden")
+  cy.getExpandedTile().find(".image-filter").should("exist").invoke("css", "visibility", "hidden")
 
   cy.wait(1000)
 

--- a/widgets/samples/tile.template.tsx
+++ b/widgets/samples/tile.template.tsx
@@ -122,7 +122,6 @@ export function ImageTemplate({
         ) : (
           <></>
         )}
-        <img class="image-element" src={image} loading="lazy" alt={tile.description || "Image"} />
       </div>
     </>
   ) : (

--- a/widgets/starter-project/tile.template.tsx
+++ b/widgets/starter-project/tile.template.tsx
@@ -115,14 +115,13 @@ export function ImageTemplate({
 }) {
   return image ? (
     <>
-      <div class="image-filler" style={{ "background-image": `url('${image}')` }}></div>
+      <div class="image-filler" style={{ "background-image": `url('https://placedog.net/500')` }}></div>
       <div class="image">
         {shopspotEnabled ? (
           <ShopSpotTemplate shopspotEnabled={shopspotEnabled} parent={parent} tileId={tile.id} />
         ) : (
           <></>
         )}
-        <img class="image-element" src={"https://placedog.net/500"} loading="lazy" alt={tile.description || "Image"} />
       </div>
     </>
   ) : (

--- a/widgets/styles/templates/expanded-tiles/_index.scss
+++ b/widgets/styles/templates/expanded-tiles/_index.scss
@@ -86,7 +86,6 @@ expanded-tiles:not(:empty) {
             background-repeat: no-repeat;
             background-size: cover;
             position: absolute;
-            filter: blur(50px) brightness(0.5);
             inset: 0;
             transform: scale(1.2);
           }

--- a/widgets/styles/templates/expanded-tiles/_index.scss
+++ b/widgets/styles/templates/expanded-tiles/_index.scss
@@ -87,7 +87,9 @@ expanded-tiles:not(:empty) {
             background-size: cover;
             position: absolute;
             inset: 0;
-            transform: scale(1.2);
+            &.blurred {
+              filter: blur(20px);
+            }
           }
         }
       }

--- a/widgets/styles/templates/expanded-tiles/_index.scss
+++ b/widgets/styles/templates/expanded-tiles/_index.scss
@@ -87,6 +87,7 @@ expanded-tiles:not(:empty) {
             background-size: cover;
             position: absolute;
             inset: 0;
+
             &.blurred {
               filter: blur(20px);
             }

--- a/widgets/styles/templates/story-line-expanded/_index.scss
+++ b/widgets/styles/templates/story-line-expanded/_index.scss
@@ -444,6 +444,7 @@ expanded-tiles:not(:empty) {
             background-size: cover;
             position: absolute;
             inset: 0;
+
             &.blurred {
               filter: blur(20px);
             }

--- a/widgets/styles/templates/story-line-expanded/_index.scss
+++ b/widgets/styles/templates/story-line-expanded/_index.scss
@@ -443,7 +443,6 @@ expanded-tiles:not(:empty) {
             background-repeat: no-repeat;
             background-size: cover;
             position: absolute;
-            filter: blur(50px) brightness(0.5);
             inset: 0;
             transform: scale(1.2);
           }

--- a/widgets/styles/templates/story-line-expanded/_index.scss
+++ b/widgets/styles/templates/story-line-expanded/_index.scss
@@ -444,7 +444,9 @@ expanded-tiles:not(:empty) {
             background-size: cover;
             position: absolute;
             inset: 0;
-            transform: scale(1.2);
+            &.blurred {
+              filter: blur(20px);
+            }
           }
         }
       }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
Improve expanded tile preloading of images before videos render, and fully stretch image


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 