### PR TITLE
chore: UGCPH-521: add ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION to workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,9 @@ on:
     workflow_call:
     workflow_dispatch:
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
     playwright-run:
         runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ permissions:
   id-token: write
 
 env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   GH_TOKEN: ${{ github.token }}
   NODE_AUTH_TOKEN: ${{secrets.STACKLA_BOT_GITHUB_TOKEN}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 run-name: Release to ${{ inputs.environment || 'staging' }} by @${{ github.actor }}
 
 env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   GH_TOKEN: ${{ github.token }}
 
 permissions:

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -12,6 +12,9 @@ permissions:
     contents: write
     pull-requests: read
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
     stale_branches:
         runs-on: ubuntu-latest


### PR DESCRIPTION
# Description of change

Add `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable to all GitHub Actions workflow files.

This temporarily opts out of the Node.js 24 default behavior to restore Node.js 20 compatibility while we plan and execute the full upgrade path to Node.js 24.

Actions will default to Node.js 24 starting June 2nd, 2026, and Node.js 20 will be removed by September 16th, 2026.

Ticket: UGCPH-521

# How have you tested your code?

Configuration-only change. No application code was modified.

# Dependencies

None.