### PR TITLE
fix: correct default product title color

### DIFF
--- a/widgets/styles/templates/products.scss
+++ b/widgets/styles/templates/products.scss
@@ -29,7 +29,7 @@
 
   &{
     --product-price-font-color: #{$black};
-    --product-title-font-color: #{$white};
+    --product-title-font-color: #{$black};
     --product-description-font-color: #{$black};
 
     display: flex;


### PR DESCRIPTION
## Description
Fixes `--product-title-font-color` defaulting to white in the base product styles placeholder, which made the expanded-tile product title invisible on the default light background.

## Motivation and Context
`--product-price-font-color` already defaulted to black, but `--product-title-font-color` defaulted to white — that combination is only correct for dark skins like `nightfall`, which already override both explicitly. On the default light background this rendered the product title as white-on-white (invisible).

## Related Jira ticket
None found — branch has no ticket reference.

## Testing
Ran the local dev server (`npm run start:test`), opened the carousel preview, clicked a tile to open the expanded product view, and inspected computed styles via Playwright before/after the fix:
- Before: title color `rgb(255, 255, 255)` (invisible), price `rgb(0, 0, 0)`
- After (compiled CSS): `--product-title-font-color: #000`, matching price

## Documentation
N/A

## Checklist
- [x] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [x] The changes are tested
- [ ] I have verified my UX changes with a designer
- [x] I have checked my code for any possible security vulnerabilities

## Screenshots
N/A